### PR TITLE
Robin/nav adjustments

### DIFF
--- a/cypress/integration/research.spec.js
+++ b/cypress/integration/research.spec.js
@@ -1,0 +1,9 @@
+describe("Research page", function () {
+  it("has hidden elements in navigation which can be found by clicking the scroller", function () {
+    cy.server();
+    cy.visit("/research/early-years/executive-summary");
+    cy.contains("Working life").then(el => Cypress.dom.isHidden(el));
+    cy.get(".scroll-help.right").click();
+    cy.contains("Working life").then(el => !Cypress.dom.isHidden(el));
+  });
+});

--- a/src/components/common/__snapshots__/research-navigation.spec.tsx.snap
+++ b/src/components/common/__snapshots__/research-navigation.spec.tsx.snap
@@ -1,0 +1,116 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Research navigation renders correctly 1`] = `
+<nav
+  className="css-13jbmd0-researchNavigationCss"
+>
+  <div
+    className="scroll-help left can-scroll"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-chevron-left fa-w-10 "
+      data-icon="chevron-left"
+      data-prefix="fas"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M34.52 239.03L228.87 44.69c9.37-9.37 24.57-9.37 33.94 0l22.67 22.67c9.36 9.36 9.37 24.52.04 33.9L131.49 256l154.02 154.75c9.34 9.38 9.32 24.54-.04 33.9l-22.67 22.67c-9.37 9.37-24.57 9.37-33.94 0L34.52 272.97c-9.37-9.37-9.37-24.57 0-33.94z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </div>
+  <ul>
+    <li
+      className="current-page css-1j62vah-ResearchNavigationLink"
+    >
+      <a
+        href="/research/early-years/executive-summary"
+      >
+        <test-file-stub />
+        <span>
+          Early years
+        </span>
+      </a>
+    </li>
+    <li
+      className="css-11cayae-ResearchNavigationLink"
+    >
+      <a
+        href="/research/school"
+      >
+        <test-file-stub />
+        <span>
+          School years
+        </span>
+      </a>
+    </li>
+    <li
+      className="css-f4i9ca-ResearchNavigationLink"
+    >
+      <a
+        href="/research/further"
+      >
+        <test-file-stub />
+        <span>
+          Further education
+        </span>
+      </a>
+    </li>
+    <li
+      className="css-kwj661-ResearchNavigationLink"
+    >
+      <a
+        href="/research/higher"
+      >
+        <test-file-stub />
+        <span>
+          Higher education
+        </span>
+      </a>
+    </li>
+    <li
+      className="css-xpwdr0-ResearchNavigationLink"
+    >
+      <a
+        href="/research/working"
+      >
+        <test-file-stub />
+        <span>
+          Working life
+        </span>
+      </a>
+    </li>
+  </ul>
+  <div
+    className="scroll-help right can-scroll"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+  >
+    <svg
+      aria-hidden="true"
+      className="svg-inline--fa fa-chevron-right fa-w-10 "
+      data-icon="chevron-right"
+      data-prefix="fas"
+      focusable="false"
+      role="img"
+      style={Object {}}
+      viewBox="0 0 320 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z"
+        fill="currentColor"
+        style={Object {}}
+      />
+    </svg>
+  </div>
+</nav>
+`;

--- a/src/components/common/header.tsx
+++ b/src/components/common/header.tsx
@@ -52,7 +52,6 @@ const headerStyles = css`
       font-weight: 600;
       line-height: 3rem;
       width: 100%;
-      margin: 0 1rem;
     }
   }
 

--- a/src/components/common/research-navigation.spec.tsx
+++ b/src/components/common/research-navigation.spec.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import renderer from "react-test-renderer";
+import ResearchNavigation from "./research-navigation";
+
+describe("Research navigation", () => {
+  it("renders correctly", () => {
+    const tree = renderer.create(<ResearchNavigation />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/src/components/common/research-navigation.tsx
+++ b/src/components/common/research-navigation.tsx
@@ -48,12 +48,19 @@ const researchNavigationCss = css`
     flex-direction: row;
     justify-content: flex-start;
     padding: 0;
-    scrollbar-width: thin;
+    scrollbar-width: none;
+    &::-webkit-scrollbar {
+      display: none;
+    }
+    /* TODO - decide whether we want a scrollbar
+    
+    scrollbar-width: none;
     scrollbar-color: transparent transparent;
     transition: scrollbar-color 0.5s linear;
     &:hover {
       scrollbar-color: rgba(0, 0, 0, 0.5) transparent;
     }
+    */
     li {
       flex-shrink: 0;
       width: unset;

--- a/src/components/common/research-navigation.tsx
+++ b/src/components/common/research-navigation.tsx
@@ -10,7 +10,7 @@ import {
 
 const researchNavigationCss = css`
   background-color: var(--white);
-  box-shadow: rgba(0, 0, 0, 0.15) 0rem 1rem 1rem;
+  box-shadow: rgba(0, 0, 0, 0.15) 0rem 0.25rem 0.375rem;
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -22,7 +22,6 @@ const researchNavigationCss = css`
     width: 2rem;
     text-align: center;
     font-size: 3rem;
-    box-shadow: rgba(0, 0, 0, 0.15) 0rem 0rem 1rem;
     cursor: pointer;
   }
 
@@ -50,30 +49,31 @@ const researchNavigationCss = css`
     }
   }
 
-  ${mq(BreakPoint.lg)} {
+  ${mq(BreakPoint.xl)} {
     .scroll-help {
       display: none;
     }
     ul {
+      padding: 0 4rem;
       overflow-x: visible;
-      justify-content: center;
     }
   }
 
   li {
     margin-left: 1rem;
     margin-right: 1rem;
-    border-bottom: 0.5rem solid rgba(255, 255, 255, 0);
+    border-bottom: 0.375rem solid transparent;
+    border-top: 0.375rem solid transparent;
     &:hover,
     &:focus,
     &:active {
-      border-color: var(--highlight-colour);
+      border-bottom-color: var(--highlight-colour);
     }
-    transition: 1s border-color ease;
+    transition: 0.6s border-color ease;
   }
 
   li.current-page {
-    border-bottom: 0.5rem solid var(--highlight-colour);
+    border-bottom-color: var(--highlight-colour);
     font-weight: 800;
   }
 `;

--- a/src/components/common/research-navigation.tsx
+++ b/src/components/common/research-navigation.tsx
@@ -48,6 +48,12 @@ const researchNavigationCss = css`
     flex-direction: row;
     justify-content: flex-start;
     padding: 0;
+    scrollbar-width: thin;
+    scrollbar-color: transparent transparent;
+    transition: scrollbar-color 0.5s linear;
+    &:hover {
+      scrollbar-color: rgba(0, 0, 0, 0.5) transparent;
+    }
     li {
       flex-shrink: 0;
       width: unset;

--- a/src/components/life-stages/life-stage-image.tsx
+++ b/src/components/life-stages/life-stage-image.tsx
@@ -29,7 +29,17 @@ interface LifeStageImage {
   node: Node;
 }
 
-export const PureLifeStageImage = ({ data, objectPosition, classNames }) => {
+interface PureLifeStageImage {
+  data: LifeStageImage;
+  objectPosition: string;
+  classNames: string[];
+}
+
+export const PureLifeStageImage = ({
+  data,
+  objectPosition,
+  classNames,
+}: PureLifeStageImage) => {
   return (
     <Img
       imgStyle={{ objectPosition }}
@@ -58,7 +68,7 @@ const LifeStageImage = ({ imageName, objectPosition, classNames }: Props) => {
     
   `);
 
-  const img = data.images.edges.find(
+  const img: LifeStageImage = data.images.edges.find(
     (image: LifeStageImage) =>
       image.node.childImageSharp.fluid.originalName === imageName
   );

--- a/src/components/research/__snapshots__/pills.test.tsx.snap
+++ b/src/components/research/__snapshots__/pills.test.tsx.snap
@@ -1,11 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Pills renders correctly 1`] = `
-<div
-  className="css-k7t418-cssPills"
+<nav
+  className="css-15dfcdf-dropdownCssMobile-cssListItem-cssList-cssPills-highlightColorCss-Pills"
 >
   <div
-    className="css-40leom-cssContent"
+    className="dropdown"
     onClick={[Function]}
   >
     Contents
@@ -32,118 +32,96 @@ exports[`Pills renders correctly 1`] = `
     </span>
   </div>
   <ol
-    className=" css-1luu7lt-cssList"
+    className="pill-list"
   >
-    <li
-      className="css-j5ezsg-cssListItem"
-    >
+    <li>
       <a
-        className="css-bvgj3n-cssActive-cssPill"
+        className="current-page"
         href="/"
       >
         Executive Summary
       </a>
     </li>
-    <li
-      className="css-j5ezsg-cssListItem"
-    >
+    <li>
       <a
-        className="css-1c796n1-cssPill"
+        className={null}
         href="/"
       >
         Early Years Foundation Stage
       </a>
     </li>
-    <li
-      className="css-j5ezsg-cssListItem"
-    >
+    <li>
       <a
-        className="css-1c796n1-cssPill"
+        className={null}
         href="/"
       >
         Family Circumstances
       </a>
     </li>
-    <li
-      className="css-j5ezsg-cssListItem"
-    >
+    <li>
       <a
-        className="css-1c796n1-cssPill"
+        className={null}
         href="/"
       >
         Social class and underachievement
       </a>
     </li>
-    <li
-      className="css-j5ezsg-cssListItem"
-    >
+    <li>
       <a
-        className="css-1c796n1-cssPill"
+        className={null}
         href="/"
       >
         School cultures
       </a>
     </li>
-    <li
-      className="css-j5ezsg-cssListItem"
-    >
+    <li>
       <a
-        className="css-1c796n1-cssPill"
+        className={null}
         href="/"
       >
         Geographical educational inequality
       </a>
     </li>
-    <li
-      className="css-j5ezsg-cssListItem"
-    >
+    <li>
       <a
-        className="css-1c796n1-cssPill"
+        className={null}
         href="/"
       >
         Type and quality of schooling
       </a>
     </li>
-    <li
-      className="css-j5ezsg-cssListItem"
-    >
+    <li>
       <a
-        className="css-1c796n1-cssPill"
+        className={null}
         href="/"
       >
         Low aspirations
       </a>
     </li>
-    <li
-      className="css-j5ezsg-cssListItem"
-    >
+    <li>
       <a
-        className="css-1c796n1-cssPill"
+        className={null}
         href="/"
       >
         Access to career advice
       </a>
     </li>
-    <li
-      className="css-j5ezsg-cssListItem"
-    >
+    <li>
       <a
-        className="css-1c796n1-cssPill"
+        className={null}
         href="/"
       >
         Gaps in attainnment
       </a>
     </li>
-    <li
-      className="css-j5ezsg-cssListItem"
-    >
+    <li>
       <a
-        className="css-1c796n1-cssPill"
+        className={null}
         href="/"
       >
         Impact of COVID-19
       </a>
     </li>
   </ol>
-</div>
+</nav>
 `;

--- a/src/components/research/pills.tsx
+++ b/src/components/research/pills.tsx
@@ -97,7 +97,13 @@ const cssList = css`
     align-items: center;
     padding-left: 1.5rem 5rem;
 
-    li a.current-page {
+    li a {
+      transition: background-color 0.6s ease;
+      background-color: transparent;
+    }
+
+    li a.current-page,
+    li a:hover {
       background-color: var(--highlight-color);
     }
   }
@@ -112,7 +118,7 @@ const cssPills = css`
 
   ${mq(BreakPoint.md)} {
     ${withPrefixes`box-shadow: none;`}
-    padding: 1.5rem 0;
+    padding: 1.5rem 4.5rem;
     background-color: var(--taupe);
 
     .dropdown {

--- a/src/components/research/pills.tsx
+++ b/src/components/research/pills.tsx
@@ -1,8 +1,7 @@
 import React, { useState } from "react";
 import { css } from "@emotion/core";
-import PropTypes from "prop-types";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faChevronUp, faChevronDown } from "@fortawesome/free-solid-svg-icons";
+import { faChevronUp } from "@fortawesome/free-solid-svg-icons";
 import { mq, BreakPoint } from "../../util/mq";
 
 const withPrefixes = style => `
@@ -12,35 +11,21 @@ const withPrefixes = style => `
     -ms-${style}
 `;
 
-const cssPills = css`
-  ${withPrefixes`box-shadow: 0 0 4px 0 rgba(0,0,0,0.2);`}
-  ${mq(BreakPoint.md)} {
-    ${withPrefixes`box-shadow: none;`}
-    padding: 1.5rem 0;
-    background-color: var(--taupe);
-  }
-`;
-
-const cssContent = css`
+const dropdownCssMobile = css`
   cursor: pointer;
   .icon {
     float: right;
     padding: 0 0.5em;
     transition: 0.6s transform ease-in-out;
+    transform: rotate(180deg);
   }
   .icon.open {
-    transform: rotate(-540deg);
+    transform: rotate(-360deg);
   }
   font-size: 1.25em;
   font-weight: 600;
   color: var(--midnight);
   padding: 12px;
-
-  ${mq(BreakPoint.md)} {
-    display: none;
-    ${withPrefixes`user-select: none;`}
-    padding: 12px 0;
-  }
 `;
 
 const cssListItem = css`
@@ -54,9 +39,9 @@ const cssListItem = css`
   }
 `;
 
-const Pill = ({ name, href, cssPill }) => (
-  <li css={cssListItem}>
-    <a css={cssPill} href={href}>
+const Pill = ({ name, href, isActive }: PillData) => (
+  <li>
+    <a className={isActive ? "current-page" : null} href={href}>
       {name}
     </a>
   </li>
@@ -73,67 +58,97 @@ type PillsProps = {
   colorActive: string;
 };
 
+const cssList = css`
+  transform: scale(1, 0);
+  max-height: 0;
+  transform-origin: 0 0;
+  transition: transform 0.6s ease-in, max-height 0.6s ease-in;
+
+  &.open {
+    transform: scale(1);
+    max-height: 40rem;
+  }
+
+  li {
+    ${cssListItem}
+    a {
+      ${withPrefixes`user-select: none;`}
+      padding: 0 12px;
+      background-color: var(--white);
+
+      ${mq(BreakPoint.md)} {
+        border-radius: 9999px;
+        border: solid 1px var(--highlight-color);
+        display: inline-block;
+        height: 100%;
+        margin: 0.25rem;
+
+        line-height: 2.75rem;
+      }
+    }
+  }
+
+  ${mq(BreakPoint.md)} {
+    transform: scale(1);
+    max-height: 40rem;
+
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    padding-left: 1.5rem 5rem;
+
+    li a.current-page {
+      background-color: var(--highlight-color);
+    }
+  }
+`;
+
+const cssPills = css`
+  ${withPrefixes`box-shadow: 0 0 4px 0 rgba(0,0,0,0.2);`}
+
+  .dropdown {
+    ${dropdownCssMobile}
+  }
+
+  ${mq(BreakPoint.md)} {
+    ${withPrefixes`box-shadow: none;`}
+    padding: 1.5rem 0;
+    background-color: var(--taupe);
+
+    .dropdown {
+      display: none;
+      ${withPrefixes`user-select: none;`}
+      padding: 12px 0;
+    }
+  }
+
+  .pill-list {
+    ${cssList}
+  }
+`;
+
 const Pills = ({ pills, colorActive }: PillsProps) => {
   const [isOpen, setOpen] = useState(false);
 
-  let cssPill = css`
-    ${withPrefixes`user-select: none;`}
-    padding: 0 12px;
-    background-color: var(--white);
-
-    ${mq(BreakPoint.md)} {
-      border-radius: 9999px;
-      border: solid 1px ${colorActive};
-      display: inline-block;
-      height: 100%;
-      margin: 0 0.25rem;
-
-      line-height: 2.75rem;
-    }
-  `;
-
-  let cssActive = css`
-    ${mq(BreakPoint.md)} {
-      background-color: ${colorActive};
-    }
-  `;
-
-  let cssList = css`
-    transform: scale(1, 0);
-    max-height: 0;
-    transform-origin: 0 0;
-    transition: transform 0.6s ease-in, max-height 0.6s ease-in;
-
-    &.open {
-      transform: scale(1);
-      max-height: 40rem;
-    }
-
-    ${mq(BreakPoint.md)} {
-      transform: scale(1);
-      max-height: 40rem;
-
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
+  const highlightColorCss = css`
+    --highlight-color: ${colorActive};
   `;
 
   return (
-    <div css={cssPills}>
-      <div css={cssContent} onClick={() => setOpen(!isOpen)}>
+    <nav css={[cssPills, highlightColorCss]}>
+      <div className="dropdown" onClick={() => setOpen(!isOpen)}>
         Contents
         <span className={["icon", isOpen ? "open" : ""].join(" ")}>
           <FontAwesomeIcon icon={faChevronUp} />
         </span>
       </div>
-      <ol css={cssList} className={isOpen ? "open" : ""}>
+      <ol className={isOpen ? "open pill-list" : "pill-list"}>
         {pills.map((pill, idx) => {
-          const cssPillInstance = [pill.isActive && cssActive, cssPill];
-          return <Pill {...pill} key={idx} cssPill={cssPillInstance} />;
+          // const cssPillInstance = [pill.isActive && cssActive, cssPill];
+          return <Pill {...pill} key={idx} />;
         })}
       </ol>
-    </div>
+    </nav>
   );
 };
 

--- a/src/components/research/pills.tsx
+++ b/src/components/research/pills.tsx
@@ -62,7 +62,7 @@ const cssList = css`
   transform: scale(1, 0);
   max-height: 0;
   transform-origin: 0 0;
-  transition: transform 0.6s ease-in, max-height 0.6s ease-in;
+  transition: transform 0.6s linear, max-height 0.6s linear;
 
   &.open {
     transform: scale(1);
@@ -74,7 +74,6 @@ const cssList = css`
     a {
       ${withPrefixes`user-select: none;`}
       padding: 0 12px;
-      background-color: var(--white);
 
       ${mq(BreakPoint.md)} {
         border-radius: 9999px;
@@ -99,7 +98,6 @@ const cssList = css`
 
     li a {
       transition: background-color 0.6s ease;
-      background-color: transparent;
     }
 
     li a.current-page,
@@ -111,6 +109,8 @@ const cssList = css`
 
 const cssPills = css`
   ${withPrefixes`box-shadow: 0 0 4px 0 rgba(0,0,0,0.2);`}
+  z-index: 1;
+  position: relative;
 
   .dropdown {
     ${dropdownCssMobile}

--- a/src/pages/research-example.js
+++ b/src/pages/research-example.js
@@ -14,8 +14,8 @@ const samplePills = [
   { name: "Type and quality of schooling", href: "/" },
   { name: "Low aspirations", href: "/" },
   { name: "Access to career advice", href: "/" },
-  { name: "Gaps in attainnment", href: "/" },
-  { name: "Impact of COVID-19", href: "/" },
+  { name: "Gaps in attainment", href: "/" },
+  { name: "Impact of Covid-19", href: "/" },
 ];
 
 const colorActive = "orange";


### PR DESCRIPTION
Updates on the nav based on a chat with @carinapope13 today. Todo list was this:

## desktop

* border-bottom-color override
* border-top transparent
* restore padding to align with ESMA title
* 1124 width brings in the arrow (because working life is hidden lower than that)
* 0.375rem for the border bottom (and top) size
* `box-shadow: rgba(0,0,0,0.15) 0rem 0.25rem 0.375rem;`
* about/get involved links need to lose `a` padding or `li` margin etc to have 30px gap
* padding in the `ol` for pills:  `padding: 1.5rem 5rem;`
* `ol` has `background-color: var(--taupe)`
* remove background color on pills anchors
* hover state highlight with transition

## mobile

* flip the contents caret to be down when closed, up when open (i.e. direction the menu will move)
* copy changes on “low aspirations”
* scrollers should disappear when we’re at the ends
* `box-shadow: rgba(0,0,0,0.1) 0rem 0.125rem 0.375rem;` on the contents pills thing in mobile, `z-index: 1`

Have to say that I'm really proud of how I got the scrollers to disappear. Tested it in Chrome and Firefox. Even did some styling to clean up the default view in Firefox.