### PR TITLE
Gatsby Link for internal links in navs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -25,7 +25,7 @@ jobs:
         run: npm run test
 
       - name: Build and export
-        run: npm run build -- --prefix-paths
+        run: npm run build
         env:
           CONTENTFUL_ACCESS_TOKEN: ${{secrets.CONTENTFUL_ACCESS_TOKEN}}
           CONTENTFUL_SPACE_ID: ${{secrets.CONTENTFUL_SPACE_ID}}

--- a/src/components/common/research-navigation.tsx
+++ b/src/components/common/research-navigation.tsx
@@ -7,6 +7,7 @@ import {
   faChevronLeft,
   faChevronRight,
 } from "@fortawesome/free-solid-svg-icons";
+import { Link } from "gatsby";
 
 const researchNavigationCss = css`
   background-color: var(--white);
@@ -111,10 +112,10 @@ const ResearchNavigationLink = ({
         --highlight-colour: ${highlightColour};
       `}
     >
-      <a href={href}>
+      <Link to={href}>
         <Icon />
         <span>{name}</span>
-      </a>
+      </Link>
     </li>
   );
 };

--- a/src/components/newsletter/__snapshots__/newsletter-sign-up.test.tsx.snap
+++ b/src/components/newsletter/__snapshots__/newsletter-sign-up.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`NewsletterSignUp renders correctly 1`] = `
             By clicking Subscribe you accept the
              
             <a
-              href="#"
+              href="/privacy"
             >
               Privacy Policy
             </a>

--- a/src/components/newsletter/newsletter-sign-up.tsx
+++ b/src/components/newsletter/newsletter-sign-up.tsx
@@ -2,7 +2,8 @@ import React, { FormEvent, useState } from "react";
 import { css } from "@emotion/core";
 import addToMailchimp from "gatsby-plugin-mailchimp";
 import { mq, BreakPoint } from "../../util/mq";
-import NewsletterInputField from './newsletter-input-field';
+import NewsletterInputField from "./newsletter-input-field";
+import { Link } from "gatsby";
 
 const newsletterSignUpStyles = css`
   padding: 4.5rem 0.75rem;
@@ -140,9 +141,12 @@ const NewsletterSignUp = () => {
     try {
       const response = await addToMailchimp(email, { FNAME: name });
       handleResult(response.result, response.msg);
-    } catch(e) {
-      setMcResponse({success: false, msg: "Something went wrong, please try again later."})
-      console.log(e)
+    } catch (e) {
+      setMcResponse({
+        success: false,
+        msg: "Something went wrong, please try again later.",
+      });
+      console.log(e);
     }
   };
 
@@ -181,7 +185,7 @@ const NewsletterSignUp = () => {
                 errorMessage="Please enter your name."
                 errorSetter={setNameError}
                 valueSetter={setName}
-                />
+              />
               <NewsletterInputField
                 label="Email address"
                 type="email"
@@ -190,7 +194,7 @@ const NewsletterSignUp = () => {
                 errorMessage="Please enter your email."
                 errorSetter={setEmailError}
                 valueSetter={setEmail}
-                />
+              />
               <section className="submitSection">
                 <label htmlFor="submit">&nbsp;</label>
                 <input type="submit" value="Submit" id="submit" />
@@ -209,9 +213,10 @@ const NewsletterSignUp = () => {
                 </p>
                 <p>
                   By clicking Subscribe you accept the{" "}
-                  <a href="#">Privacy Policy</a>. This will allow us to send you
-                  newsletter and event updates. Our Privacy Policy covers how we
-                  protect data. You can unsubscribe from this at any point.
+                  <Link to="/privacy">Privacy Policy</Link>. This will allow us
+                  to send you newsletter and event updates. Our Privacy Policy
+                  covers how we protect data. You can unsubscribe from this at
+                  any point.
                 </p>
               </section>
             </fieldset>

--- a/src/components/research/__snapshots__/pills.test.tsx.snap
+++ b/src/components/research/__snapshots__/pills.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Pills renders correctly 1`] = `
 <nav
-  className="css-uec49b-dropdownCssMobile-cssListItem-cssList-cssPills-highlightColorCss-Pills"
+  className="css-1pufbqy-dropdownCssMobile-cssListItem-cssList-cssPills-highlightColorCss-Pills"
 >
   <div
     className="dropdown"

--- a/src/components/research/__snapshots__/prev-next.spec.tsx.snap
+++ b/src/components/research/__snapshots__/prev-next.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`PrevNext renders correctly 1`] = `
 <nav
-  className="css-98r2c1-arrowHoverCss-prevNextCss-highlightColorCss-PrevNext"
+  className="css-ebx9bh-arrowHoverCss-prevNextCss-highlightColorCss-PrevNext"
 >
   <div
     aria-hidden="true"

--- a/src/components/research/pills.tsx
+++ b/src/components/research/pills.tsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronUp } from "@fortawesome/free-solid-svg-icons";
 import { mq, BreakPoint } from "../../util/mq";
 import { PillsProps, PillData } from "./types";
+import { Link } from "gatsby";
 
 const withPrefixes = style => `
     ${style}
@@ -42,9 +43,9 @@ const cssListItem = css`
 
 const Pill = ({ name, href, isActive }: PillData & { isActive: boolean }) => (
   <li>
-    <a className={isActive ? "current-page" : null} href={href}>
+    <Link className={isActive ? "current-page" : null} to={href}>
       {name}
-    </a>
+    </Link>
   </li>
 );
 

--- a/src/components/research/prev-next.tsx
+++ b/src/components/research/prev-next.tsx
@@ -4,6 +4,7 @@ import { mq, BreakPoint } from "../../util/mq";
 import { PillsProps } from "./types";
 import Arrow, { arrowHoverCss } from "../common/arrow";
 import EarlyDevIcon from "../../svg/blocks.svg";
+import { Link } from "gatsby";
 
 const withPrefixes = style => `
     ${style}
@@ -140,7 +141,7 @@ const PrevNextLink = ({
     return <></>;
   }
   return (
-    <a href={pills[index].href} className="prev-next-box" css={customCss}>
+    <Link to={pills[index].href} className="prev-next-box" css={customCss}>
       <h4>
         <span className="label">{type}</span>
         <Arrow />
@@ -154,7 +155,7 @@ const PrevNextLink = ({
       <div className="mobile-arrow">
         <Arrow />
       </div>
-    </a>
+    </Link>
   );
 };
 

--- a/src/components/timeline/__snapshots__/timeline-entry.test.tsx.snap
+++ b/src/components/timeline/__snapshots__/timeline-entry.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`TimelineEntry renders correctly 1`] = `
   href="#"
 >
   <div
-    className="css-1ubqytx-arrowHoverCss-timelineEntryStyles"
+    className="css-gbs4w9-arrowHoverCss-timelineEntryStyles"
   >
     <div
       className="timeline-image-wrapper gatsby-image-wrapper"

--- a/src/components/timeline/timeline-entry.tsx
+++ b/src/components/timeline/timeline-entry.tsx
@@ -3,6 +3,7 @@ import TimelineImage from "./timeline-image";
 import { css } from "@emotion/core";
 import { mq, BreakPoint } from "../../util/mq";
 import Arrow, { arrowHoverCss } from "../common/arrow";
+import { Link } from "gatsby";
 
 const timelineEntryStyles = css`
   transition: all 0.333s ease-out 0s;
@@ -78,7 +79,7 @@ interface Props {
 const TimelineEntry = ({ title, imageName, description, icon }: Props) => {
   const Icon = icon;
   return (
-    <a href="#">
+    <Link to="#">
       <div css={timelineEntryStyles}>
         <TimelineImage imageName={imageName} />
         <h2>{title}</h2>
@@ -90,7 +91,7 @@ const TimelineEntry = ({ title, imageName, description, icon }: Props) => {
           <Arrow />
         </div>
       </div>
-    </a>
+    </Link>
   );
 };
 


### PR DESCRIPTION
Fixes an issue in the built site.

## Bug description

At [the Early Years life stage overview](https://redbadger.github.io/esma-website/research/early-years/executive-summary/), the links in the Research Navigation and Pills aren't prefixed with `/esma-website`.

## The fix

First, `import { Link } from "gatsby";` and then use `<Link to={…}>` instead of `<a href={…}>`.