### PR TITLE
applying flip to both before and after

### DIFF
--- a/src/components/common/filtered-hero-image.tsx
+++ b/src/components/common/filtered-hero-image.tsx
@@ -13,7 +13,8 @@ const backgroundCss = css`
     z-index: -1;
   }
 
-  ::after {
+  ::after,
+  ::before {
     transform: scaleX(-1);
   }
 `;


### PR DESCRIPTION
There was a bug with the header on Operational Review where the image was initially loaded flipped, then on refresh flipped back again. This is fixed by flipping both the `::before` and `::after` elements, as it looks like the `::before` is used when the image is already cached and the `::after` otherwise.