### PR TITLE
package-lock update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2774,9 +2774,9 @@
       }
     },
     "@mdx-js/react": {
-      "version": "2.0.0-next.7",
-      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.0.0-next.7.tgz",
-      "integrity": "sha512-VugV3o0zOD6pABtQEDDWNxiU8f+tS4KMiOgnwNiyxxOEwEZgBnXfMhZYDtHfrnhHxS59ValJ5zITnbdBwPbJkA=="
+      "version": "1.6.21",
+      "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.21.tgz",
+      "integrity": "sha512-CgSNT9sq2LAlhEbVlPg7DwUQkypz+CWaWGcJbkgmp9WCAy6vW33CQ44UbKPiH3wet9o+UbXeQOqzZd041va83g=="
     },
     "@mdx-js/runtime": {
       "version": "2.0.0-next.7",
@@ -2786,6 +2786,13 @@
         "@mdx-js/mdx": "^2.0.0-next.7",
         "@mdx-js/react": "^2.0.0-next.7",
         "buble-jsx-only": "^0.19.8"
+      },
+      "dependencies": {
+        "@mdx-js/react": {
+          "version": "2.0.0-next.8",
+          "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.0.0-next.8.tgz",
+          "integrity": "sha512-I/ped8Wb1L4sUlumQmUlYQsH0tjd2Zj2eyCWbqgigpg+rtRlNFO9swkeyr0GY9hNZnwI8QOnJtNe+UdIZim8LQ=="
+        }
       }
     },
     "@mdx-js/util": {
@@ -11114,6 +11121,11 @@
         "yup": "^0.27.0"
       },
       "dependencies": {
+        "@mdx-js/react": {
+          "version": "2.0.0-next.8",
+          "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-2.0.0-next.8.tgz",
+          "integrity": "sha512-I/ped8Wb1L4sUlumQmUlYQsH0tjd2Zj2eyCWbqgigpg+rtRlNFO9swkeyr0GY9hNZnwI8QOnJtNe+UdIZim8LQ=="
+        },
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",


### PR DESCRIPTION
Apparently this didn't happen on the most recent `npm install` and the github workflow broke:

https://github.com/redbadger/esma-website/actions/runs/374828772

This ought to fix it. `npm ci` runs successfully for me locally now that I've made this change.
