### PR TITLE
Single column on research pages

### DIFF
--- a/src/components/research/__snapshots__/footnotes.test.tsx.snap
+++ b/src/components/research/__snapshots__/footnotes.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Footnotes renders correctly 1`] = `
 <div
-  className="css-1v40p0u-footnoteStyles"
+  className="css-1d04iqu-footnoteStyles"
   id="footnotes"
 >
   <h3>

--- a/src/components/research/__snapshots__/further-reading.test.tsx.snap
+++ b/src/components/research/__snapshots__/further-reading.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`FurtherReading renders correctly 1`] = `
 <div
-  className="further-reading-container css-1s6vae-furtherReadingStyles"
+  className="further-reading-container css-1e497tz-furtherReadingStyles"
   role="list"
 >
   <ul>

--- a/src/components/research/__snapshots__/research-quote.test.tsx.snap
+++ b/src/components/research/__snapshots__/research-quote.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ResearchQuote renders correctly 1`] = `
 <div
-  className="css-18a8le6-containerStyles"
+  className="css-soql84-containerStyles"
 >
   <div
     className="css-1fjfpf6-researchQuoteStyles"

--- a/src/components/research/__snapshots__/resizable-graph.test.tsx.snap
+++ b/src/components/research/__snapshots__/resizable-graph.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ResizableGraph renders correctly 1`] = `
 <div
-  className=" css-i5zxf-ResizableGraph"
+  className=" css-6jyuqd-ResizableGraph"
 >
   <p>
     Sample heading

--- a/src/components/research/footnotes.tsx
+++ b/src/components/research/footnotes.tsx
@@ -4,7 +4,7 @@ import { mq, BreakPoint } from "../../util/mq";
 
 const footnoteStyles = css`
   ${mq(BreakPoint.lg)} {
-    grid-column: 1 / span 2;
+    grid-column: 1 / -1;
   }
 
   font-size: 1rem;

--- a/src/components/research/further-reading.tsx
+++ b/src/components/research/further-reading.tsx
@@ -7,7 +7,7 @@ const furtherReadingStyles = css`
   border: 1px solid;
   border-radius: 0.625rem;
   padding: 1.5rem 0.75rem;
-  grid-column: 1 / span 2;
+  grid-column: 1 / -1;
   display: grid;
   ${mq(BreakPoint.md)} {
     grid-template-columns: 1fr 1fr;

--- a/src/components/research/research-quote.tsx
+++ b/src/components/research/research-quote.tsx
@@ -41,14 +41,15 @@ const researchQuoteStyles = css`
 
 const containerStyles = css`
   ${mq(BreakPoint.lg)} {
-    grid-column: 1 / span 2;
+    grid-column: 1 / -1;
   }
   color: var(--midnight);
 
   .quote-source {
     margin-top: 0.75rem;
     margin-bottom: 0;
-    span, a {
+    span,
+    a {
       font-size: 1rem;
       line-height: 1.875rem;
     }

--- a/src/components/research/resizable-graph.tsx
+++ b/src/components/research/resizable-graph.tsx
@@ -5,7 +5,7 @@ import { css } from "@emotion/core";
 
 const graphContainerStyles = (fullSpan: boolean) => css`
   ${mq(BreakPoint.lg)} {
-    ${fullSpan ? "grid-column: 1 / span  2" : ""};
+    ${fullSpan ? "grid-column: 1 / -1" : ""};
   }
 `;
 
@@ -24,7 +24,7 @@ const ResizableGraph = ({
   desktop,
   fullSpan,
   children,
-  className
+  className,
 }: ResizableGraphProps) => {
   const { width } = useWindowSize();
 
@@ -40,7 +40,7 @@ const ResizableGraph = ({
 
   return (
     <div className={className} css={graphContainerStyles(fullSpan)}>
-        {children}
+      {children}
       <Graph />
     </div>
   );
@@ -48,7 +48,7 @@ const ResizableGraph = ({
 
 ResizableGraph.defaultProps = {
   fullSpan: true,
-  className: ""
+  className: "",
 };
 
 export default ResizableGraph;

--- a/src/templates/life-stage.tsx
+++ b/src/templates/life-stage.tsx
@@ -150,7 +150,7 @@ const contentBodyStyles = css`
 
   ${mq(BreakPoint.lg)} {
     .full-span {
-      grid-column: 1 / span 2;
+      grid-column: 1 / -1;
     }
   }
 
@@ -185,7 +185,7 @@ const contentBodyStyles = css`
   }
 
   ${mq(BreakPoint.lg)} {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: minmax(75rem, 1fr);
   }
 
   p {

--- a/src/templates/life-stage.tsx
+++ b/src/templates/life-stage.tsx
@@ -185,7 +185,7 @@ const contentBodyStyles = css`
   }
 
   ${mq(BreakPoint.lg)} {
-    grid-template-columns: minmax(75rem, 1fr);
+    grid-template-columns: minmax(auto, 75rem);
   }
 
   p {


### PR DESCRIPTION
This PR converts the research pages to a single column layout.

It does so without removing grid which is doing some heavy work and allows for easy switching back to two-column later.

All the `.full-span` and similar elements are now using the standard `grid-column: 1 / -1;` property so they will be full span no matter how many columns the pages have.

It also introduces a maxmium width of the single grid column of `75rem` (generally `1200px`) which prevents an overly wide display on wide desktops.